### PR TITLE
fix error "Callback must be a function" issue with NodeJS 10

### DIFF
--- a/lib/runner/runner.js
+++ b/lib/runner/runner.js
@@ -67,7 +67,7 @@ Runner.writeInLessFile = function (path, filename, lessFiles) {
         output += '@import "'+relativePath+'";'+"\n";
     }
 
-    fs.appendFile(compiledFilename, output);
+    fs.appendFile(compiledFilename, output, function () {});
 
     return compiledFilename;
 };


### PR DESCRIPTION
https://nodejs.org/api/fs.html#fs_fs_appendfile_path_data_options_callback

v10.0.0 | The callback parameter is no longer optional. Not passing it will throw a TypeError at runtime.


